### PR TITLE
COMP: Fix build by adding missing return value

### DIFF
--- a/LiverResections/Widgets/qSlicerLiverResectionsTableView.cxx
+++ b/LiverResections/Widgets/qSlicerLiverResectionsTableView.cxx
@@ -216,12 +216,12 @@ void qSlicerLiverResectionsTableView::setMRMLScene(vtkMRMLScene* newScene)
 //------------------------------------------------------------------------------
 bool qSlicerLiverResectionsTableView::eventFilter(QObject* target, QEvent* event)
 {
+  return false;
 }
 
 //------------------------------------------------------------------------------
 void qSlicerLiverResectionsTableView::contextMenuEvent(QContextMenuEvent* event)
 {
-
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
I added a return false statement, which allows the event to be processed further. If the intention of this empty event filter is to stop processing, should return true.